### PR TITLE
Migrate i18nPropsForScripts to grunt-sh-i18n-props

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,6 @@ build-dev/resources/shape/<appName>/i18n/<locale>/tempaltes/
 
 The key point in this example is **the dust template file must be put together with the properties file in the same folder**.
 
-#### options.getScriptsPropsFilePath
-Type: `Function`
-
-Returned value type: `String`, this is **`required`**
-
-It return the generated localized javascript properties file path in deployment folder structure. 
-
 #### options.keyPrefix
 Type: `String`
 
@@ -92,33 +85,6 @@ This config option is **`required`**
 
 It specify the keyPrefix in all properties files under i18n folder to make sure all the properties key have to conform to the key constrains. 
 
-#### options.i18nPropsId
-Type: `String`
-
-This config option is **`required`**
-
-It specify the module id of generated i18n properties file, See below exmaple:
-
-If the options has the following config
-
-```javascript
-options: {
-    ...
-    i18nPropsId: 'geolocation-i18nProps'
-    ...
-}
-```
-
-Then the generated i18nPropsForScripts.js will be like below:
-```javascript
-define('geolocation-i18nProps', [], function(){
-    return {
-        "common.components.geolocation.defaultLink.text": "all locations",
-        "common.components.geolocation.popular-in.text": "Popular events in&nbsp;",
-        "common.components.geolocation.popular-near.text": "Popular events near&nbsp;"
-    };
-});
-```
 
 #### options.i18nPropsDeps
 Type: `Array`
@@ -141,12 +107,6 @@ Default value: `['scripts/**/*.properties']`, this is **`optional`**
 
 It specify where the scripts properties file locate, it should be relative to the locale's folder. Normally, this value should not be changed and app can just accept the default value.
 
-#### options.scriptsPropsFileName
-Type: `Array`
-
-Default value: `'i18nPropsForScripts'`, this is **`optional`**
-
-It specify the generated javascript properties file name.
 
 ### Usage Examples
 
@@ -176,19 +136,6 @@ meventdev: {
             
             templatespath = filepath.split(sep).slice(2).join(sep);
             destpath = path.join(localesRootPath, locale, templatespath);
-
-            return destpath;
-        },
-        getScriptsPropsFilePath: function (settings) {
-            var task = settings.task,
-                locale = settings.locale,
-                scriptsPropsFileName = settings.scriptsPropsFileName,
-                buildDevPath = grunt.config.get('buildDevPath'),
-                multiFeatureScriptsPath = grunt.config.get('multiFeatureScriptsPath'),
-                destpath = '';
-
-            destpath = path.join(buildDevPath, multiFeatureScriptsPath, locale, scriptsPropsFileName + '.js');
-            grunt.verbose.subhead('[precompile] ==== scriptsPropsFilePath-----', destpath);                        
 
             return destpath;
         },
@@ -222,17 +169,6 @@ dev:{
 
             templatespath = filepath.split(sep).slice(1).join(sep);
             destpath = path.join(i18nRootPath, locale, templatespath);
-
-            return destpath;
-        },
-        getScriptsPropsFilePath: function (settings) {
-            var locale = settings.locale,
-                scriptsPropsFileName = settings.scriptsPropsFileName,
-                buildDevPath = grunt.config.get('buildDevPath'),
-                featureScriptsPath = grunt.config.get('featureScriptsPath'),
-                destpath = '';
-            
-            destpath = path.join(buildDevPath, featureScriptsPath, locale, scriptsPropsFileName + '.js');
 
             return destpath;
         },

--- a/i18nPropsForScripts.tpl
+++ b/i18nPropsForScripts.tpl
@@ -1,5 +1,0 @@
-define('{i18nPropsId}', [{i18nPropsDeps}], function(){
-
-    return {{i18nPropsJson}};
-    
-});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-sh-precompile",
   "description": "Grunt plugin for precompile dust template specific to Stubhub",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "homepage": "https://github.com/StubHubLabs/grunt-sh-precompile",
   "author": {
     "name": "yongbchen",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.corp.ebay.com/yongbchen/sh-precompile.git"
+    "url": "https://github.com/StubHubLabs/grunt-sh-precompile"
   },
   "bugs": {
     "url": ""

--- a/tasks/sh_precompile.js
+++ b/tasks/sh_precompile.js
@@ -17,8 +17,7 @@ module.exports = function(grunt) {
          // Merge task-specific and/or target-specific options with these defaults.
         var options = this.options({
                 commonPropsSrc: ['common/**/*.properties'],
-                scriptsPropsSrc: ['scripts/**/*.properties'],
-                scriptsPropsFileName: 'i18nPropsForScripts'
+                scriptsPropsSrc: ['scripts/**/*.properties']
             }),
             filesSrc = this.filesSrc,
             i18nRegExp = /\{@i18n\s+?key=["](.+?)["]\s*?\/}/gmi,
@@ -29,7 +28,6 @@ module.exports = function(grunt) {
             fs = require('fs'),
             _ = require('underscore'),
             parser = require('properties-parser'), // Please refer to https://github.com/xavi-/node-properties-parser
-            i18nPropsForScriptsTemplateFile = '../i18nPropsForScripts.tpl',
             itself = this,
             util = {};
 
@@ -250,72 +248,12 @@ module.exports = function(grunt) {
                     scriptsPropsJsonList.push(scriptsPropsJson);
                 });
 
-                grunt.log.writeln(('[precompile] ==== available locale list is: ').bold.blue, localesList);
-                grunt.log.writeln(('[precompile] ==== commonPropsJsonList is: ').bold.blue, commonPropsJsonList);
-                grunt.log.writeln(('[precompile] ==== scriptsPropsJsonList is: ').bold.blue, scriptsPropsJsonList);
+                grunt.verbose.writeln(('[precompile] ==== available locale list is: ').bold.blue, localesList);
+                grunt.verbose.writeln(('[precompile] ==== commonPropsJsonList is: ').bold.blue, commonPropsJsonList);
+                grunt.verbose.writeln(('[precompile] ==== scriptsPropsJsonList is: ').bold.blue, scriptsPropsJsonList);
 
             },
-            // Combile commonPropsJson with scriptsPropsJson to generate a new sripts properties for each locale
-            generateScriptsProps: function(options) {
 
-                var scriptsPropsFileName = options.scriptsPropsFileName;
-                var i18nPropsId = options.i18nPropsId || '';
-                var i18nPropsDeps = options.i18nPropsDeps || [];
-                var localesList = this.getLocalesList();
-                var commonPropsJsonList = this.getCommonPropsJsonList();
-                var scriptsPropsJsonList = this.getScriptsPropsJsonList();
-                var getScriptsPropsFilePath = options.getScriptsPropsFilePath;
-                var _this = this;
-
-                localesList.forEach(function(locale) {
-                    var commonPropsJson = {},
-                        scriptsPropsJson = {},
-                        content = '',
-                        destPath = '';
-
-                    destPath = getScriptsPropsFilePath({
-                        locale: locale,
-                        scriptsPropsFileName: scriptsPropsFileName,
-                        task: itself
-                    });
-
-                    _.some(commonPropsJsonList, function(obj) {
-                        if (obj[locale]) {
-                            commonPropsJson = obj[locale];
-                            return true;
-                        }
-                    });
-
-                    _.some(scriptsPropsJsonList, function(obj) {
-                        if (obj[locale]) {
-                            scriptsPropsJson = obj[locale];
-                            return true;
-                        }
-                    });
-
-                    scriptsPropsJson = _.extend({}, commonPropsJson, scriptsPropsJson);
-
-                    grunt.verbose.subhead('[precompile] **** scriptsPropsJson', scriptsPropsJson);
-
-                    content = grunt.file.read(path.join(__dirname, i18nPropsForScriptsTemplateFile));
-
-                    // replace the {i18nPropsId} and {i18nPropsDeps} with real i18n props module definition
-                    content = content.replace('{i18nPropsId}', i18nPropsId);
-                    i18nPropsDeps = JSON.stringify(i18nPropsDeps);
-                    i18nPropsDeps = i18nPropsDeps.substr(1, i18nPropsDeps - 2);
-                    content = content.replace('{i18nPropsDeps}', i18nPropsDeps);
-
-                    // Pretty print the JSON file format
-                    scriptsPropsJson = JSON.stringify(scriptsPropsJson, null, 4);
-                    scriptsPropsJson = scriptsPropsJson.replace(new RegExp(eol + _this.createSpace(4), 'mg'), eol + _this.createSpace(8));
-                    scriptsPropsJson = scriptsPropsJson.replace('}', _this.createSpace(4) + '}');
-
-                    content = content.replace('{{i18nPropsJson}}', scriptsPropsJson);
-
-                    grunt.file.write(destPath, content);
-
-                });
-            },
             // Copy all the source dust template files to each targeted locale folder.
             copyTemplateFiles: function(options) {
 
@@ -474,9 +412,7 @@ module.exports = function(grunt) {
                     'localeFilesExpandPatterns',
                     'implementedLocalesList',
                     'getTemplateFilePath',
-                    'getScriptsPropsFilePath',
-                    'keyPrefix',
-                    'i18nPropsId'
+                    'keyPrefix'
                 ];
 
                 itself.requiresConfig.apply(itself, _.map(requiredOptions, function(val) {
@@ -508,7 +444,6 @@ module.exports = function(grunt) {
             },
 
             start: function(options) {
-                this.generateScriptsProps(options);
                 this.copyTemplateFiles(options);
                 this.generateLocalizedTemplates(options);
             }


### PR DESCRIPTION
Hi @jackchen83 

As part of the component and string decoupling projects that KK has been working on, I offered him to migrate all of the i18nPropsForScripts functionality out of `grunt-sh-precompile` into a new [grunt-sh-i18n-props](https://www.npmjs.com/package/grunt-sh-i18n-props) npm module.

Can you please review and publish to npm? I don't have rights :( ...

I just removed code from here and put it in [grunt-sh-i18n-props](https://www.npmjs.com/package/grunt-sh-i18n-props)

I changed version to 1.0.0 because the changes - on purpose - are non backwards compatible.

Thanks!
